### PR TITLE
Retry on UrlFetch calls with muteHttpExceptions

### DIFF
--- a/src/ErrorHandler.gs.js
+++ b/src/ErrorHandler.gs.js
@@ -6,6 +6,7 @@
  * And makes sure that caught errors are correctly logged in Stackdriver
  *
  * expBackoff()
+ * urlFetchWithExpBackOff()
  * logError()
  *
  * _convertErrorStack()
@@ -139,7 +140,7 @@ function expBackoff(func) {
  * 
  * @return {UrlFetchApp.HTTPResponse}  - fetch response
  */
-function expBackOffFetch(url, params) {
+function urlFetchWithExpBackOff(url, params) {
   params = params || {};
   
   params.muteHttpExceptions = true;
@@ -207,7 +208,7 @@ function logError(e, additionalParams) {
 this['ErrorHandler'] = {
   // Add local alias to run the library as normal code
   expBackoff: expBackoff,
-  expBackOffFetch: expBackOffFetch,
+  urlFetchWithExpBackOff: urlFetchWithExpBackOff,
   logError: logError
 };
 

--- a/src/ErrorHandler.gs.js
+++ b/src/ErrorHandler.gs.js
@@ -106,6 +106,24 @@ function expBackoff(func) {
 }
 
 /**
+ * Helper function to automatically handles exponential backoff on UrlFetch use
+ *
+ * @param {string} url
+ * @param {Object} params
+ * 
+ * @return {UrlFetchApp.HTTPResponse}  - fetch response
+ */
+function expBackOffFetch(url, params) {
+  params = params || {};
+  
+  params.muteHttpExceptions = true;
+  
+  return ErrorHandler.expBackoff(function(){
+    return UrlFetchApp.fetch(url, params);
+  });
+}
+
+/**
  * If we simply log the error object, only the error message will be submitted to Stackdriver Logging
  * Best to re-write the error as a new object to get lineNumber & stack trace
  * 
@@ -163,6 +181,7 @@ function logError(e, additionalParams) {
 this['ErrorHandler'] = {
   // Add local alias to run the library as normal code
   expBackoff: expBackoff,
+  expBackOffFetch: expBackOffFetch,
   logError: logError
 };
 


### PR DESCRIPTION
* Check if response is from a UrlFetch call with muteHttpExceptions activated
* Check responseCode
* if 500, perform exponential backoff
* in case of failure after exponential backoff, don't throw an error, return response & log issue in Stackdriver