### PR TITLE
Fix issue where response is undefined

### DIFF
--- a/src/ErrorHandler.gs.js
+++ b/src/ErrorHandler.gs.js
@@ -54,7 +54,7 @@ function expBackoff(func) {
     
     
     // Handle retries on UrlFetch calls with muteHttpExceptions
-    if (noError && typeof response.getResponseCode === "function") {
+    if (noError && response && typeof response.getResponseCode === "function") {
       isUrlFetchResponse = true;
       
       var responseCode = response.getResponseCode();


### PR DESCRIPTION
The function 'func' passed as parameter can return nothing. In that case variable 'response' will be undefined.
Thus, check if response is defined before checking if response has a getResponseCode property.